### PR TITLE
[#117512347] Replace all occurrences of cf-platform-eng

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # Configuration
 
-A sample configuration can be found at [config-sample.json](https://github.com/cf-platform-eng/rds-broker/blob/master/config-sample.json).
+A sample configuration can be found at [config-sample.json](https://github.com/alphagov/paas-rds-broker/blob/master/config-sample.json).
 
 ## General Configuration
 
@@ -9,7 +9,7 @@ A sample configuration can be found at [config-sample.json](https://github.com/c
 | log_level  | Y        | String | Broker Log Level (DEBUG, INFO, ERROR, FATAL)
 | username   | Y        | String | Broker Auth Username
 | password   | Y        | String | Broker Auth Password
-| rds_config | Y        | Hash   | [RDS Broker configuration](https://github.com/cf-platform-eng/rds-broker/blob/master/CONFIGURATION.md#rds-broker-configuration)
+| rds_config | Y        | Hash   | [RDS Broker configuration](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#rds-broker-configuration)
 
 ## RDS Broker Configuration
 
@@ -20,7 +20,7 @@ A sample configuration can be found at [config-sample.json](https://github.com/c
 | allow_user_provision_parameters| N        | Boolean | Allow users to send arbitrary parameters on provision calls (defaults to `false`)
 | allow_user_update_parameters   | N        | Boolean | Allow users to send arbitrary parameters on update calls (defaults to `false`)
 | allow_user_bind_parameters     | N        | Boolean | Allow users to send arbitrary parameters on bind calls (defaults to `false`)
-| catalog                        | Y        | Hash    | [RDS Broker catalog](https://github.com/cf-platform-eng/rds-broker/blob/master/CONFIGURATION.md#rds-broker-catalog)
+| catalog                        | Y        | Hash    | [RDS Broker catalog](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#rds-broker-catalog)
 
 ## RDS Broker catalog
 
@@ -30,7 +30,7 @@ Please refer to the [Catalog Documentation](https://docs.cloudfoundry.org/servic
 
 | Option   | Required | Type      | Description
 |:---------|:--------:|:--------- |:-----------
-| services | N        | []Service | A list of [Services](https://github.com/cf-platform-eng/rds-broker/blob/master/CONFIGURATION.md#service)
+| services | N        | []Service | A list of [Services](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#service)
 
 ### Service
 
@@ -49,7 +49,7 @@ Please refer to the [Catalog Documentation](https://docs.cloudfoundry.org/servic
 | metadata.supportUrl           | N        | String        | Link to support for the service
 | requires                      | N        | []String      | A list of permissions that the user would have to give the service, if they provision it (only `syslog_drain` is supported)
 | plan_updateable               | N        | Boolean       | Whether the service supports upgrade/downgrade for some plans
-| plans                         | N        | []ServicePlan | A list of [Plans](https://github.com/cf-platform-eng/rds-broker/blob/master/CONFIGURATION.md#service-plan) for this service
+| plans                         | N        | []ServicePlan | A list of [Plans](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#service-plan) for this service
 | dashboard_client.id           | N        | String        | The id of the Oauth2 client that the service intends to use
 | dashboard_client.secret       | N        | String        | A secret for the dashboard client
 | dashboard_client.redirect_uri | N        | String        | A domain for the service dashboard that will be whitelisted by the UAA to enable SSO
@@ -65,7 +65,7 @@ Please refer to the [Catalog Documentation](https://docs.cloudfoundry.org/servic
 | metadata.costs       | N        | Cost Object   | An array-of-objects that describes the costs of a service, in what currency, and the unit of measure
 | metadata.displayName | N        | String        | Name of the plan to be display in graphical clients
 | free                 | N        | Boolean       | This field allows the plan to be limited by the non_basic_services_allowed field in a Cloud Foundry Quota
-| rds_properties       | Y        | RDSProperties | [RDS Properties](https://github.com/cf-platform-eng/rds-broker/blob/master/CONFIGURATION.md#rds-properties)
+| rds_properties       | Y        | RDSProperties | [RDS Properties](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#rds-properties)
 
 ## RDS Properties
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV GOARM       5
 ENV GOOS        linux
 
 # Build BOSH Registry
-RUN go get -a -installsuffix cgo -ldflags '-s' github.com/cf-platform-eng/rds-broker
+RUN go get -a -installsuffix cgo -ldflags '-s' github.com/alphagov/paas-rds-broker
 
 # Add files
 ADD Dockerfile.final /go/bin/Dockerfile

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/cf-platform-eng/rds-broker",
+	"ImportPath": "github.com/alphagov/paas-rds-broker",
 	"GoVersion": "go1.5.1",
 	"Packages": [
 		"./..."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS RDS Service Broker [![Build Status](https://travis-ci.org/cf-platform-eng/rds-broker.png)](https://travis-ci.org/cf-platform-eng/rds-broker)
+# AWS RDS Service Broker [![Build Status](https://travis-ci.org/alphagov/paas-rds-broker.png)](https://travis-ci.org/alphagov/paas-rds-broker)
 
 This is an **experimental** [Cloud Foundry Service Broker](https://docs.cloudfoundry.org/services/overview.html) for [Amazon Relational Database Service (RDS)](https://aws.amazon.com/rds/) supporting [Aurora](https://aws.amazon.com/rds/aurora/), [MariaDB](https://aws.amazon.com/rds/mariadb/), [MySQL](https://aws.amazon.com/rds/mysql/) and [PostgreSQL](https://aws.amazon.com/rds/postgresql/) RDS Databases.
 
@@ -15,7 +15,7 @@ This is **NOT** presently a production ready Service Broker. This is a work in p
 Using the standard `go install` (you must have [Go](https://golang.org/) already installed in your local machine):
 
 ```
-$ go install github.com/cf-platform-eng/rds-broker
+$ go install github.com/alphagov/paas-rds-broker
 $ rds-broker -port=3000 -config=<path-to-your-config-file>
 ```
 
@@ -24,11 +24,11 @@ $ rds-broker -port=3000 -config=<path-to-your-config-file>
 The broker can be deployed to an already existing [Cloud Foundry](https://www.cloudfoundry.org/) installation:
 
 ```
-$ git clone https://github.com/cf-platform-eng/rds-broker.git
+$ git clone https://github.com/alphagov/paas-rds-broker.git
 $ cd rds-broker
 ```
 
-Modify the [included manifest file](https://github.com/cf-platform-eng/rds-broker/blob/master/manifest.yml) to include your AWS credentials and optionally the [sample configuration file](https://github.com/cf-platform-eng/rds-broker/blob/master/config-sample.json). Then you can push the broker to your [Cloud Foundry](https://www.cloudfoundry.org/) environment:
+Modify the [included manifest file](https://github.com/alphagov/paas-rds-broker/blob/master/manifest.yml) to include your AWS credentials and optionally the [sample configuration file](https://github.com/alphagov/paas-rds-broker/blob/master/config-sample.json). Then you can push the broker to your [Cloud Foundry](https://www.cloudfoundry.org/) environment:
 
 ```
 $ cp config-sample.json config.json
@@ -46,10 +46,10 @@ $ docker run -d --name rds-broker -p 3000:3000 \
   cfplatformeng/rds-broker
 ```
 
-The Docker image cames with an [embedded sample configuration file](https://github.com/cf-platform-eng/rds-broker/blob/master/config-sample.json). If you want to override it, you can create the Docker image with you custom configuration file by running:
+The Docker image cames with an [embedded sample configuration file](https://github.com/alphagov/paas-rds-broker/blob/master/config-sample.json). If you want to override it, you can create the Docker image with you custom configuration file by running:
 
 ```
-$ git clone https://github.com/cf-platform-eng/rds-broker.git
+$ git clone https://github.com/alphagov/paas-rds-broker.git
 $ cd rds-broker
 $ bin/build-docker-image
 ```
@@ -60,9 +60,9 @@ This broker can be deployed using the [AWS Service Broker BOSH Release](https://
 
 ## Configuration
 
-Refer to the [Configuration](https://github.com/cf-platform-eng/rds-broker/blob/master/CONFIGURATION.md) instructions for details about configuring this broker.
+Refer to the [Configuration](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md) instructions for details about configuring this broker.
 
-This broker gets the AWS credentials from the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. It requires a user with some [IAM](https://aws.amazon.com/iam/) & [RDS](https://aws.amazon.com/rds/) permissions. Refer to the [iam_policy.json](https://github.com/cf-platform-eng/rds-broker/blob/master/iam_policy.json) file to check what actions the user must be allowed to perform.
+This broker gets the AWS credentials from the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. It requires a user with some [IAM](https://aws.amazon.com/iam/) & [RDS](https://aws.amazon.com/rds/) permissions. Refer to the [iam_policy.json](https://github.com/alphagov/paas-rds-broker/blob/master/iam_policy.json) file to check what actions the user must be allowed to perform.
 
 ## Usage
 
@@ -79,7 +79,7 @@ Configure and deploy the broker using one of the above methods. Then:
 
 Application Developers can start to consume the services using the standard [CF CLI commands](https://docs.cloudfoundry.org/devguide/services/managing-services.html).
 
-Depending on the [broker configuration](https://github.com/cf-platform-eng/rds-broker/blob/master/CONFIGURATION.md#rds-broker-configuration), Application Depevelopers can send arbitrary parameters on certain broker calls:
+Depending on the [broker configuration](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#rds-broker-configuration), Application Depevelopers can send arbitrary parameters on certain broker calls:
 
 #### Provision
 
@@ -129,12 +129,12 @@ Here are some ways *you* can contribute:
 * by writing specifications
 * by writing code (**no patch is too small**: fix typos, add comments, clean up inconsistent whitespace)
 * by refactoring code
-* by closing [issues](https://github.com/cf-platform-eng/rds-broker/issues)
+* by closing [issues](https://github.com/alphagov/paas-rds-broker/issues)
 * by reviewing patches
 
 ### Submitting an Issue
 
-We use the [GitHub issue tracker](https://github.com/cf-platform-eng/rds-broker/issues) to track bugs and features. Before submitting a bug report or feature request, check to make sure it hasn't already been submitted. You can indicate support for an existing issue by voting it up. When submitting a bug report, please include a [Gist](http://gist.github.com/) that includes a stack trace and any details that may be necessary to reproduce the bug, including your Golang version and operating system. Ideally, a bug report should include a pull request with failing specs.
+We use the [GitHub issue tracker](https://github.com/alphagov/paas-rds-broker/issues) to track bugs and features. Before submitting a bug report or feature request, check to make sure it hasn't already been submitted. You can indicate support for an existing issue by voting it up. When submitting a bug report, please include a [Gist](http://gist.github.com/) that includes a stack trace and any details that may be necessary to reproduce the bug, including your Golang version and operating system. Ideally, a bug report should include a pull request with failing specs.
 
 ### Submitting a Pull Request
 
@@ -146,4 +146,4 @@ We use the [GitHub issue tracker](https://github.com/cf-platform-eng/rds-broker/
 
 ## Copyright
 
-Copyright (c) 2015 Pivotal Software Inc. See [LICENSE](https://github.com/cf-platform-eng/rds-broker/blob/master/LICENSE) for details.
+Copyright (c) 2015 Pivotal Software Inc. See [LICENSE](https://github.com/alphagov/paas-rds-broker/blob/master/LICENSE) for details.

--- a/awsrds/fakes/fake_db_cluster.go
+++ b/awsrds/fakes/fake_db_cluster.go
@@ -1,7 +1,7 @@
 package fakes
 
 import (
-	"github.com/cf-platform-eng/rds-broker/awsrds"
+	"github.com/alphagov/paas-rds-broker/awsrds"
 )
 
 type FakeDBCluster struct {

--- a/awsrds/fakes/fake_db_instance.go
+++ b/awsrds/fakes/fake_db_instance.go
@@ -1,7 +1,7 @@
 package fakes
 
 import (
-	"github.com/cf-platform-eng/rds-broker/awsrds"
+	"github.com/alphagov/paas-rds-broker/awsrds"
 )
 
 type FakeDBInstance struct {

--- a/awsrds/rds_db_cluster_test.go
+++ b/awsrds/rds_db_cluster_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker/awsrds"
+	. "github.com/alphagov/paas-rds-broker/awsrds"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker/awsrds"
+	. "github.com/alphagov/paas-rds-broker/awsrds"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"

--- a/awsrds/utils_test.go
+++ b/awsrds/utils_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker/awsrds"
+	. "github.com/alphagov/paas-rds-broker/awsrds"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"

--- a/config.go
+++ b/config.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/cf-platform-eng/rds-broker/rdsbroker"
+	"github.com/alphagov/paas-rds-broker/rdsbroker"
 )
 
 type Config struct {

--- a/config_test.go
+++ b/config_test.go
@@ -4,9 +4,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker"
+	. "github.com/alphagov/paas-rds-broker"
 
-	"github.com/cf-platform-eng/rds-broker/rdsbroker"
+	"github.com/alphagov/paas-rds-broker/rdsbroker"
 )
 
 var _ = Describe("Config", func() {

--- a/main.go
+++ b/main.go
@@ -15,9 +15,9 @@ import (
 	"github.com/frodenas/brokerapi"
 	"github.com/pivotal-golang/lager"
 
-	"github.com/cf-platform-eng/rds-broker/awsrds"
-	"github.com/cf-platform-eng/rds-broker/rdsbroker"
-	"github.com/cf-platform-eng/rds-broker/sqlengine"
+	"github.com/alphagov/paas-rds-broker/awsrds"
+	"github.com/alphagov/paas-rds-broker/rdsbroker"
+	"github.com/alphagov/paas-rds-broker/sqlengine"
 )
 
 var (

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -10,9 +10,9 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pivotal-golang/lager"
 
-	"github.com/cf-platform-eng/rds-broker/awsrds"
-	"github.com/cf-platform-eng/rds-broker/sqlengine"
-	"github.com/cf-platform-eng/rds-broker/utils"
+	"github.com/alphagov/paas-rds-broker/awsrds"
+	"github.com/alphagov/paas-rds-broker/sqlengine"
+	"github.com/alphagov/paas-rds-broker/utils"
 )
 
 const defaultUsernameLength = 16

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -6,15 +6,15 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker/rdsbroker"
+	. "github.com/alphagov/paas-rds-broker/rdsbroker"
 
 	"github.com/frodenas/brokerapi"
 	"github.com/pivotal-golang/lager"
 	"github.com/pivotal-golang/lager/lagertest"
 
-	"github.com/cf-platform-eng/rds-broker/awsrds"
-	rdsfake "github.com/cf-platform-eng/rds-broker/awsrds/fakes"
-	sqlfake "github.com/cf-platform-eng/rds-broker/sqlengine/fakes"
+	"github.com/alphagov/paas-rds-broker/awsrds"
+	rdsfake "github.com/alphagov/paas-rds-broker/awsrds/fakes"
+	sqlfake "github.com/alphagov/paas-rds-broker/sqlengine/fakes"
 )
 
 var _ = Describe("RDS Broker", func() {

--- a/rdsbroker/catalog_test.go
+++ b/rdsbroker/catalog_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker/rdsbroker"
+	. "github.com/alphagov/paas-rds-broker/rdsbroker"
 )
 
 var _ = Describe("Catalog", func() {

--- a/rdsbroker/config_test.go
+++ b/rdsbroker/config_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker/rdsbroker"
+	. "github.com/alphagov/paas-rds-broker/rdsbroker"
 )
 
 var _ = Describe("Config", func() {

--- a/sqlengine/fakes/fake_provider.go
+++ b/sqlengine/fakes/fake_provider.go
@@ -1,7 +1,7 @@
 package fakes
 
 import (
-	"github.com/cf-platform-eng/rds-broker/sqlengine"
+	"github.com/alphagov/paas-rds-broker/sqlengine"
 )
 
 type FakeProvider struct {

--- a/sqlengine/provider_service_test.go
+++ b/sqlengine/provider_service_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker/sqlengine"
+	. "github.com/alphagov/paas-rds-broker/sqlengine"
 
 	"github.com/pivotal-golang/lager"
 )

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cf-platform-eng/rds-broker/utils"
+	. "github.com/alphagov/paas-rds-broker/utils"
 )
 
 var _ = Describe("RandomAlphaNum", func() {


### PR DESCRIPTION
# What

As a part of [Forked Service Broker Deployed to Production](https://www.pivotaltracker.com/story/show/117512347) story we forked the https://github.com/cf-platform-eng repository.

Now, we want all includes to point to our fork so cf-platform-eng/rds-broker is replaced
with alphagov/paas-rds-broker
# How to test

```
go get .
go test 
go build .
```
# Who can review

Not @combor or @timmow
